### PR TITLE
Include sources to be able to build better-sqlite3 for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/index.js",
   "files": [
     "binding.gyp",
-    "src/*.[ch]pp",
+    "src/*",
     "lib/**",
     "deps/**"
   ],


### PR DESCRIPTION
This PR should include source files so we can build better-sqlite3 directly when building packages for CoreP Server

1. Checkout this PR
2. Run yarn install
3.  Run `yarn lzz` to confirm that this command doesn't throw any errors and there's no any changes in any files
4. Switch [to this PR](https://github.com/silverorange/emrap-corependium/pull/3331) for CoreP Server
5. Point `"better-sqlite3"` in CoreP Server `package.json` to your local version of better-sqlite3 package ("better-sqlite3": "file:../../better-sqlite3")
6. Run `rm -rf node_modules && pnpm install && pnpm start` to confirm that there's no any errors
7.  Run `pnpm db:clean && pnpm db:update` from CoreP server root directory (this one is time consuming and might take a while to complete)
8.   Test if the app db generated in step 7 works as expected (especially offline search with synonyms) on both Android and iOS